### PR TITLE
Fix the self.model.predict crash

### DIFF
--- a/sources/agent.py
+++ b/sources/agent.py
@@ -22,6 +22,7 @@ tf.logging.set_verbosity(tf.logging.ERROR)
 import keras.backend.tensorflow_backend as backend
 from keras.optimizers import Adam
 from keras.models import load_model, Model
+from keras.backend import set_session
 sys.stdin = stdin
 sys.stderr = stderr
 
@@ -36,6 +37,8 @@ class ARTDQNAgent:
         # Set to show an output from Conv2D layer
         self.show_conv_cam = (id + 1) in settings.CONV_CAM_AGENTS
 
+        self.sess = tf.Session()
+
         # Main model (agent does not use target model)
         self.model = self.create_model(prediction=True)
 
@@ -47,6 +50,8 @@ class ARTDQNAgent:
 
     # Load or create a new model (loading a model is being used only when playing or by trainer class that inherits from agent)
     def create_model(self, prediction=False):
+
+        set_session(self.sess)
 
         # If there is a patht to the model set, load model
         if self.model_path:

--- a/sources/trainer.py
+++ b/sources/trainer.py
@@ -21,6 +21,7 @@ sys.stderr = open(os.devnull, 'w')
 import tensorflow as tf
 tf.logging.set_verbosity(tf.logging.ERROR)
 import keras.backend.tensorflow_backend as backend
+from keras.backend import set_session
 sys.stdin = stdin
 sys.stderr = stderr
 
@@ -28,6 +29,8 @@ sys.stderr = stderr
 # Trainer class
 class ARTDQNTrainer(ARTDQNAgent):
     def __init__(self, model_path):
+
+        self.sess = tf.Session()
 
         # If model path is beiong passed in - use it instead of creating a new one
         self.model_path = model_path
@@ -107,6 +110,7 @@ class ARTDQNTrainer(ARTDQNAgent):
             current_states.append((np.array([[transition[0][1]] for transition in minibatch]) - 50) / 50)
         # We need to use previously saved graph here as this is going to be called from separate thread
         with self.graph.as_default():
+            set_session(self.sess)
             current_qs_list = self.model.predict(current_states, settings.PREDICTION_BATCH_SIZE)
 
         # Get future states from minibatch, then query NN model for Q values


### PR DESCRIPTION
The trainer was always in the waiting state, so for testing I have added some print debugging and made the ConsoleStats output less invasive (https://pastebin.com/TAiCVhGD).
With these changes, when running `train.py`, I could see that self.model.predict throws an error: https://pastebin.com/raw/w9cLY8LM

To fix the trainer crash, I have applied the suggestion from https://github.com/tensorflow/tensorflow/issues/28287#issuecomment-495005162.

I'm not familiar with tensorflow, so I don't know if I've fixed the problem correctly;
now the trainer is no longer stuck in the waiting state.

related issue: #3